### PR TITLE
Disable default frame rate limit for games

### DIFF
--- a/configs/properties/system.prop
+++ b/configs/properties/system.prop
@@ -58,3 +58,7 @@ ro.hardware.wlan.vendor=qcom
 
 # Xiaomi
 ro.product.mod_device=mondrian
+
+# Disable default frame rate limit for games
+debug.graphics.game_default_frame_rate.disabled=1
+


### PR DESCRIPTION
Android 15 limits refresh rate to 60hz for games unless we enable the developer option 'Disable default frame rate for games' manually.
Adding this prop enables it by default.

It seems that you have removed that by accident?